### PR TITLE
docs: clarify local-only storage in f-droid metadata and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Forget about manual clocking. Let your phone do it for you.
 
 Your data belongs to you.
 
+- **Local-Only Storage**: The app operates entirely offline. Your data is stored locally on your device in a private SQLite database and is never uploaded to any server or hosted backend.
 - **CSV Export**: Generate comprehensive reports of your work history in standard CSV format, ready for Excel or Google Sheets.
 - **Easy Import**: Migrate your data or restore backups seamlessly via CSV.
 

--- a/metadata/de/full_description.txt
+++ b/metadata/de/full_description.txt
@@ -11,6 +11,7 @@ Vergiss manuelles Stempeln. Lass dein Smartphone das für dich erledigen.
 
 Datenfreiheit:
 Deine Daten gehören dir.
+- Lokale Speicherung: Die App läuft vollständig offline. Deine Daten werden lokal auf deinem Gerät in einer privaten SQLite-Datenbank gespeichert und niemals auf einen Server oder ein gehostetes Backend hochgeladen.
 - CSV-Export: Generiere umfassende Berichte deiner Arbeitshistorie im Standard-CSV-Format, bereit für Excel oder Google Sheets.
 - Einfacher Import: Migriere deine Daten oder stelle Backups nahtlos via CSV wieder her.
 

--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -11,6 +11,7 @@ Forget about manual clocking. Let your phone do it for you.
 
 Data Freedom:
 Your data belongs to you.
+- Local-Only Storage: The app operates entirely offline. Your data is stored locally on your device in a private SQLite database and is never uploaded to any server or hosted backend.
 - CSV Export: Generate comprehensive reports of your work history in standard CSV format, ready for Excel or Google Sheets.
 - Easy Import: Migrate your data or restore backups seamlessly via CSV.
 


### PR DESCRIPTION
This PR updates the F-Droid metadata (full descriptions in English and German) and the project README to clarify that the application stores data 100% locally on the device (offline) and does not send data to any remote server or hosted backend. This resolves the question regarding the sync endpoint / NonFreeNet AntiFeature on the F-Droid merge request.