### PR TITLE
Android Status Bar (White on White) in Expo SDK 56 fix

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -21,6 +21,12 @@ const plugins = [
             },
         },
     ],
+    [
+        'expo-status-bar',
+        {
+            style: 'auto',
+        },
+    ],
 ]
 
 if (!isFOSS) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "expo-router": "~56.2.11",
         "expo-sharing": "~56.0.18",
         "expo-sqlite": "~56.0.5",
+        "expo-status-bar": "~56.0.4",
         "expo-system-ui": "~56.0.5",
         "expo-task-manager": "~56.0.19",
         "i18next": "26.3.1",

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -13,6 +13,7 @@ import {
     Provider as PaperProvider,
 } from 'react-native-paper'
 import { getMaterialColors } from '@expo/ui/jetpack-compose'
+import { StatusBar } from 'expo-status-bar'
 import { getSetting, setSetting } from '../db/database'
 
 export type ThemeMode = 'auto' | 'light' | 'dark'
@@ -53,11 +54,11 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
         setSetting('themeMode', mode)
     }
 
-    const paperTheme = (() => {
-        const isDark =
-            themeMode === 'dark' ||
-            (themeMode === 'auto' && systemColorScheme === 'dark')
+    const isDark =
+        themeMode === 'dark' ||
+        (themeMode === 'auto' && systemColorScheme === 'dark')
 
+    const paperTheme = (() => {
         const baseTheme = isDark ? MD3DarkTheme : MD3LightTheme
 
         if (Platform.OS !== 'android') {
@@ -124,7 +125,10 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
     return (
         <ThemeContext value={{ themeMode, setThemeMode: handleSetTheme }}>
-            <PaperProvider theme={paperTheme}>{children}</PaperProvider>
+            <PaperProvider theme={paperTheme}>
+                <StatusBar style={isDark ? 'light' : 'dark'} />
+                {children}
+            </PaperProvider>
         </ThemeContext>
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5197,6 +5197,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-status-bar@npm:~56.0.4":
+  version: 56.0.4
+  resolution: "expo-status-bar@npm:56.0.4"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/74790ea40ebfd0f7928864b2f5bb8e7893030df46828f954ffedde931702192ab4b9ca41aa972e37457c1e6658b19e0a4266ebbecc243ccd3e9b78abccebe6c6
+  languageName: node
+  linkType: hard
+
 "expo-symbols@npm:^56.0.6":
   version: 56.0.6
   resolution: "expo-symbols@npm:56.0.6"
@@ -9376,6 +9387,7 @@ __metadata:
     expo-router: "npm:~56.2.11"
     expo-sharing: "npm:~56.0.18"
     expo-sqlite: "npm:~56.0.5"
+    expo-status-bar: "npm:~56.0.4"
     expo-system-ui: "npm:~56.0.5"
     expo-task-manager: "npm:~56.0.19"
     i18next: "npm:26.3.1"


### PR DESCRIPTION
Fixes the status bar styling on Android in Expo SDK 56.

### Changes:
1. Installed `expo-status-bar` as a direct dependency.
2. Added the `expo-status-bar` config plugin to `app.config.js` with `style: 'auto'`.
3. Updated `ThemeContext.tsx` to dynamically render `<StatusBar style={isDark ? 'light' : 'dark'} />` based on the user's active theme and system theme configuration. This ensures status bar text/icons are visible (dark icons on light background and vice versa).